### PR TITLE
Open scheduler modal from calculator talk button

### DIFF
--- a/index.js
+++ b/index.js
@@ -67,6 +67,51 @@ function calculateTotal() {
   document.getElementById("total").innerText = "$" + (subscription + contribution);
 }
 
+function isCalculatorTalkButton(element) {
+  const button = element.closest("button, a");
+  if (!button) return null;
+
+  const text = button.textContent.replace(/\s+/g, " ").trim().toLowerCase();
+  const inlineClick = button.getAttribute("onclick") || "";
+  const href = button.getAttribute("href") || "";
+  const opensContactPage = inlineClick.indexOf("joincrowdhealth.com/contact") !== -1 || href.indexOf("/contact") !== -1;
+  const isTalkButton = text === "talk to an expert" || text === "talk to us";
+
+  return opensContactPage && isTalkButton ? button : null;
+}
+
+function findSchedulerModalTrigger(excludedButton) {
+  const triggers = document.querySelectorAll('a[href="#"][data-w-id]');
+
+  for (let i = 0; i < triggers.length; i += 1) {
+    const trigger = triggers[i];
+    const text = trigger.textContent.replace(/\s+/g, " ").trim().toLowerCase();
+
+    if (trigger !== excludedButton && (text === "talk to an expert" || text === "talk to us")) {
+      return trigger;
+    }
+  }
+
+  return null;
+}
+
+function setupCalculatorSchedulerModalBridge() {
+  document.addEventListener("click", function(event) {
+    const calculatorTalkButton = isCalculatorTalkButton(event.target);
+    if (!calculatorTalkButton) return;
+
+    const schedulerTrigger = findSchedulerModalTrigger(calculatorTalkButton);
+    if (!schedulerTrigger) return;
+
+    event.preventDefault();
+    event.stopPropagation();
+    event.stopImmediatePropagation();
+    schedulerTrigger.click();
+  }, true);
+}
+
+setupCalculatorSchedulerModalBridge();
+
 
 /* This will start auto-playing the slide when enter 100px in viewport from top…
 Also do not make slider Auto-Play in Webflow. */ 


### PR DESCRIPTION
## Summary
- Intercept the embedded calculator's contact-style talk button before its inline `window.open('/contact')` handler runs.
- Reuse the existing Webflow scheduler modal trigger by clicking the page's native `Talk to an expert` trigger.
- Support both `Talk to an expert` and `Talk to us` labels so the bridge keeps working if the embed copy changes.

## Validation
- Ran `node --check` against the updated branch file streamed from GitHub.

## Publish note
The live Webflow page currently loads `https://cdn.jsdelivr.net/gh/nickolascrim/crowdhealth-website@v2.1.0/index.js`. After this merges, publish a new tag/version and update the Webflow custom JS URL to that version so jsDelivr serves the change.